### PR TITLE
Now only uses self-hosted for tests

### DIFF
--- a/.github/workflows/docker_image_release.yml
+++ b/.github/workflows/docker_image_release.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
     name: Build and run daeploy Manager
-    runs-on: [self-hosted, ubuntu, ibm]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     docs: 
       name: Build and push docs to GH pages
-      runs-on: [self-hosted, ubuntu, ibm]
+      runs-on: ubuntu-latest
       steps: 
         -   uses: actions/checkout@v2
             with:

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -29,7 +29,7 @@ jobs:
 
   provision:
     name: Provision a new docker container
-    runs-on: [self-hosted, ubuntu, ibm]
+    runs-on: ubuntu-latest
     steps:
     
     - name: Checkout code

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: [self-hosted, ubuntu, ibm]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Build documentation failed on self-hosted runners. Now set up the workflows like we had them before
