### PR TITLE
Fix logs export/search: drop invalid tail=all from full_url

### DIFF
--- a/manager/routers/logging_api.py
+++ b/manager/routers/logging_api.py
@@ -69,7 +69,7 @@ def manager_logs_view(request: Request):
             "title": "manager",
             "subtitle": f"v: {get_manager_version()}",
             "stream_url": "/logs/stream?follow=true&tail=400",
-            "full_url": "/logs/stream?tail=all",
+            "full_url": "/logs/stream",
             "export_basename": "manager",
             "manager_version": get_manager_version(),
         },

--- a/manager/routers/service_api.py
+++ b/manager/routers/service_api.py
@@ -340,7 +340,7 @@ def service_logs_view(request: Request, name: str, version: str):
             "title": name,
             "subtitle": f"v{version}",
             "stream_url": f"{base}&follow=true&tail=200",
-            "full_url": f"{base}&tail=all",
+            "full_url": base,
             "export_basename": f"{name}_v{version}",
             "manager_version": get_manager_version(),
         },

--- a/tests/manager_test/test_ui_redesign.py
+++ b/tests/manager_test/test_ui_redesign.py
@@ -144,14 +144,18 @@ def test_logs_view_is_full_bleed():
 def test_service_logs_view_full_url_and_basename(test_client_logged_in):
     r = test_client_logged_in.get("/services/~logs/view?name=demo&version=0.1.0")
     assert r.status_code == 200
-    assert "/services/~logs?name=demo&version=0.1.0&tail=all" in r.text
+    # full_url omits tail so the endpoint receives tail=None -> Docker "all".
+    # Passing the literal tail=all 422s (the param is typed int).
+    assert '"/services/~logs?name=demo&version=0.1.0"' in r.text
+    assert "tail=all" not in r.text
     assert 'EXPORT_BASENAME = "demo_v0.1.0"' in r.text
 
 
 def test_manager_logs_view_full_url_and_basename(test_client):
     r = test_client.get("/logs/view")
     assert r.status_code == 200
-    assert "/logs/stream?tail=all" in r.text
+    assert '"/logs/stream"' in r.text
+    assert "tail=all" not in r.text
     assert 'EXPORT_BASENAME = "manager"' in r.text
 
 


### PR DESCRIPTION
## Problem

Exporting (or searching) logs in the new logs view saved a 150-byte JSON error instead of the log:

```json
{"detail":[{"type":"int_parsing","loc":["query","tail"],"msg":"Input should be a valid integer, unable to parse string as an integer","input":"all"}]}
```

`full_url` was built with `tail=all`, but `/services/~logs` and `/logs/stream` type `tail` as `Optional[int]`, so FastAPI 422s on `"all"`. Both **export** and **search** fetch `FULL_URL`, so both were broken.

## Fix

Omit `tail` from `full_url`. The endpoint then receives `tail=None`, and the runtime connector already maps a falsy `tail` to Docker's `"all"` (whole log) — see `runtime_connectors.py` `"tail": tail if tail else "all"`.

- `manager/routers/service_api.py` — service log view `full_url` → `base` (no tail)
- `manager/routers/logging_api.py` — manager log view `full_url` → `/logs/stream`
- `tests/manager_test/test_ui_redesign.py` — guard tests previously asserted the buggy `tail=all`; now assert `full_url` carries no tail and `tail=all` is absent.

## Verification

- `tail=all` → 422 (reproduced the bug); omitted/int `tail` → reaches handler (200).
- 17/17 `test_ui_redesign.py` pass; black ✓, flake8 ✓, pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)