### PR TITLE
Dashboard: bias content to top with a small capped gap

### DIFF
--- a/manager/assets/dashboard_styles.css
+++ b/manager/assets/dashboard_styles.css
@@ -36,7 +36,11 @@ a{color:inherit;text-decoration:none;}
 }
 .grid{
   display:grid;grid-template-columns:2.6fr 0.9fr;gap:1.4rem;align-items:start;
-  margin-block:auto;width:100%;
+  width:100%;
+  /* Bias content toward the top with a small, capped gap below the banner —
+     the remaining viewport slack falls below, so a few short rows no longer
+     float to mid-screen with a large empty band above. */
+  margin-top:clamp(0.5rem, 5vh, 2.5rem);
 }
 
 /* ---------- panels ---------- */

--- a/tests/manager_test/test_ui_redesign.py
+++ b/tests/manager_test/test_ui_redesign.py
@@ -176,10 +176,13 @@ def test_dashboard_grid_widens_services_and_fills_viewport():
     # Services hero is wider than the slim Notifications rail
     assert "grid-template-columns:2.6fr0.9fr" in css
     assert "grid-template-columns:1.85fr1fr" not in css
-    # Page fills the viewport height (minus the banner) and centers when short
+    # Page fills the viewport height (minus the banner); content is biased to
+    # the top with a small, capped gap (not centered, which floated the panels
+    # to mid-screen and left a large gap above on tall monitors).
     assert "min-height:calc(100vh-4rem)" in css
-    assert "margin-block:auto" in css
     assert "box-sizing:border-box" in css
+    assert "margin-block:auto" not in css  # no full-height vertical centering
+    assert "margin-top:clamp(" in css  # small capped top gap on .grid
 
 
 def test_notifications_panel_has_explanation():


### PR DESCRIPTION
## Problem

PR #94 vertically centered the dashboard grid (`.grid { margin-block:auto }`) inside a full-viewport `.page`. With only a few short service rows, the panels float to **mid-screen**, leaving a large empty band above them on tall monitors (reported from the live server).

## Fix

Replace the full-height centering with a **small, capped top gap** and let the remaining viewport slack fall below:

- `.grid`: drop `margin-block:auto`; add `margin-top: clamp(0.5rem, 5vh, 2.5rem)`.
- `.page` keeps `min-height:calc(100vh - 4rem)` + `box-sizing:border-box` + flex column.

Content now sits just below the banner with a small, intentional gap (not glued, not centered). Guard test `test_dashboard_grid_widens_services_and_fills_viewport` updated to assert no `margin-block:auto` and a `margin-top:clamp(` gap.

## Verification

20/20 `test_ui_redesign.py` pass; black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)