### PR TITLE
Dashboard: tighten service-row density

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.5.0
+
+### New Features
+
+- Logs viewer: in-page search with match highlighting and a match count, one-click export of the full log to a file, and a responsive full-screen console (both service and manager logs).
+- Dashboard polish: wider Services panel with a slim, self-explanatory Notifications rail; `LOGS`/`DOCS` rendered as clear buttons with keyboard focus rings; content biased to the top with a small capped gap; and denser service rows so more services fit without scrolling.
+
+### Bugfixes
+
+- Logs export and search now return the actual log instead of a validation error (the view no longer requests the invalid `tail=all`).
+- Stabilized the flaky `test_read_timerange` SDK test (a concurrent database clean could trim rows mid-test).
+
 ## 1.4.0
 
 ### New Features

--- a/manager/assets/dashboard_styles.css
+++ b/manager/assets/dashboard_styles.css
@@ -62,7 +62,7 @@ a{color:inherit;text-decoration:none;}
   grid-template-columns:1.3fr .7fr auto;
   grid-template-areas:"id state actions";
   align-items:center;gap:.8rem;
-  padding:.95rem 1.2rem;border-bottom:1px solid var(--line-soft);
+  padding:.5rem 1.2rem;border-bottom:1px solid var(--line-soft);
   transition:background .15s;
 }
 .svc:last-child{border-bottom:none}

--- a/tests/manager_test/test_ui_redesign.py
+++ b/tests/manager_test/test_ui_redesign.py
@@ -194,6 +194,14 @@ def test_notifications_panel_has_explanation():
     assert ".panel-sub" in css
 
 
+def test_service_rows_are_compact():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    assert ".svc{" in css
+    svc_block = css.split(".svc{", 1)[1].split("}", 1)[0]
+    # tight vertical row padding so more services fit without scrolling
+    assert "padding:.5rem1.2rem" in svc_block
+
+
 def test_service_links_look_like_buttons():
     css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
     # .lnk is now a bordered pill, not underline-on-hover text


### PR DESCRIPTION
Reduce `.svc` vertical padding `.95rem`→`.5rem` so more services fit without scrolling (previewed live and approved). Guard test asserts the compact padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)