### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.5.0
+
+### New Features
+
+- Logs viewer: in-page search with match highlighting and a match count, one-click export of the full log to a file, and a responsive full-screen console (both service and manager logs).
+- Dashboard polish: wider Services panel with a slim, self-explanatory Notifications rail; `LOGS`/`DOCS` rendered as clear buttons with keyboard focus rings; content biased to the top with a small capped gap; and denser service rows so more services fit without scrolling.
+
+### Bugfixes
+
+- Logs export and search now return the actual log instead of a validation error (the view no longer requests the invalid `tail=all`).
+- Stabilized the flaky `test_read_timerange` SDK test (a concurrent database clean could trim rows mid-test).
+
 ## 1.4.0
 
 ### New Features

--- a/docs/superpowers/plans/2026-06-29-dashboard-main-page-polish.md
+++ b/docs/superpowers/plans/2026-06-29-dashboard-main-page-polish.md
@@ -1,0 +1,307 @@
+# Dashboard Main-Page Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the manager dashboard so Services is the clear hero, Notifications is a slim self-explanatory rail, LOGS/DOCS read as buttons, and short content no longer leaves a top-heavy void.
+
+**Architecture:** Frontend-only. Two files: `manager/routers/dashboard_api.py` (Dash layout markup — one added subtitle element) and `manager/assets/dashboard_styles.css` (all styling). Guard tests are string-assert checks in `tests/manager_test/test_ui_redesign.py`, matching the existing pattern (read the CSS file / `str(app.layout)` and assert substrings).
+
+**Tech Stack:** Dash (Plotly) layout in Python, plain CSS with design tokens from `tokens.css`, pytest guard tests via `test_client` fixtures in `tests/conftest.py`.
+
+## Global Constraints
+
+- No backend, API, endpoint, or data-model changes. CSS + one markup element only.
+- No external resources: CSS must contain no `http://` or `https://` (enforced by `test_dashboard_css_uses_tokens`).
+- Reuse existing design tokens from `tokens.css` (`var(--muted)`, `var(--line)`, `var(--accent)`, etc.) — introduce no new colors.
+- The logs view page (`logs.html`), login, and `max-width:1600px` on `.page` stay as-is. Do not reintroduce `max-width:1180px` (guarded by `test_dashboard_page_width_widened`).
+- Run before pushing: `/home/kaveh/miniconda3/bin/python -m black --check`, `... -m flake8`, `... -m pylint manager`, and `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py`.
+- Mobile rule `@media (max-width:760px){ .grid{grid-template-columns:1fr} ... }` must keep collapsing the grid to one column.
+
+---
+
+### Task 1: Widen Services / slim sidebar + vertical fill
+
+**Files:**
+- Modify: `manager/assets/dashboard_styles.css` (the `.page` rule at line 32 and the `.grid` rule at line 33)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: the `.grid` / `.page` CSS shape that Task 2 and Task 3 visually sit inside; no code symbols.
+
+Current CSS (lines 31-33):
+
+```css
+/* ---------- page / grid ---------- */
+.page{max-width:1600px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
+.grid{display:grid;grid-template-columns:1.85fr 1fr;gap:1.4rem;align-items:start}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/manager_test/test_ui_redesign.py`:
+
+```python
+def test_dashboard_grid_widens_services_and_fills_viewport():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    # Services hero is wider than the slim Notifications rail
+    assert "grid-template-columns:2.6fr0.9fr" in css
+    assert "grid-template-columns:1.85fr1fr" not in css
+    # Page fills the viewport height (minus the banner) and centers when short
+    assert "min-height:calc(100vh-4rem)" in css
+    assert "margin-block:auto" in css
+    assert "box-sizing:border-box" in css
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_dashboard_grid_widens_services_and_fills_viewport" -v`
+Expected: FAIL (`assert "grid-template-columns:2.6fr0.9fr" in css` is False — file still has `1.85fr 1fr`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace lines 31-33 of `manager/assets/dashboard_styles.css` with:
+
+```css
+/* ---------- page / grid ---------- */
+.page{
+  max-width:1600px;margin:0 auto;padding:1.8rem 1.6rem 4rem;
+  box-sizing:border-box;min-height:calc(100vh - 4rem);
+  display:flex;flex-direction:column;
+}
+.grid{
+  display:grid;grid-template-columns:2.6fr 0.9fr;gap:1.4rem;align-items:start;
+  margin-block:auto;width:100%;
+}
+```
+
+Notes for the implementer:
+- `vh` is viewport-relative, so `min-height:calc(100vh - 4rem)` makes `.page` nearly fill the screen without touching `body` or Dash's wrapper divs. The `4rem` budgets for the top banner.
+- `box-sizing:border-box` is required because there is no global reset and `.page` has padding; without it the padding would add to the `100vh` height and force a scrollbar.
+- `margin-block:auto` on `.grid` centers it vertically inside the tall `.page` when there is spare room; when the grid is taller than the page the auto margins collapse to 0 and the page grows/scrolls normally.
+- `width:100%` keeps the grid full-width inside the flex column (a flex item would otherwise shrink to content width).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_dashboard_grid_widens_services_and_fills_viewport" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manager/assets/dashboard_styles.css tests/manager_test/test_ui_redesign.py
+git commit -m "Dashboard: widen Services, slim sidebar, fill viewport height"
+```
+
+---
+
+### Task 2: Explain the Notifications panel
+
+**Files:**
+- Modify: `manager/routers/dashboard_api.py` (the Notifications panel head in `app.layout`, around lines 334-340)
+- Modify: `manager/assets/dashboard_styles.css` (add `.panel-sub` near the `.panel-head` rules, ~line 44)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: a `<p class="panel-sub">` element with the literal subtitle text below; relied on only by its own test.
+
+Current markup (lines 334-345 of `dashboard_api.py`):
+
+```python
+        # Notifications panel
+        html.Section(
+            className="panel",
+            children=[
+                html.Div(
+                    className="panel-head",
+                    children=[html.H2("Notifications")],
+                ),
+                html.Div(
+                    id="notifications-content",
+                    children=[generate_table_notifications()],
+                ),
+            ],
+        ),
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/manager_test/test_ui_redesign.py`:
+
+```python
+def test_notifications_panel_has_explanation():
+    from manager.routers import dashboard_api
+
+    layout = str(dashboard_api.app.layout)
+    assert "Alerts services raise" in layout  # one-line description of the panel
+    css = (ASSETS / "dashboard_styles.css").read_text()
+    assert ".panel-sub" in css
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_notifications_panel_has_explanation" -v`
+Expected: FAIL (`assert "Alerts services raise" in layout` is False — no subtitle yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `manager/routers/dashboard_api.py`, change the Notifications `panel-head` children to include a subtitle (replace the single-child `panel-head` Div shown above):
+
+```python
+                html.Div(
+                    className="panel-head",
+                    children=[
+                        html.Div(
+                            [
+                                html.H2("Notifications"),
+                                html.P(
+                                    "Alerts services raise via the SDK"
+                                    " notify() — info, warnings, critical.",
+                                    className="panel-sub",
+                                ),
+                            ]
+                        )
+                    ],
+                ),
+```
+
+Then add the `.panel-sub` style to `manager/assets/dashboard_styles.css` immediately after the `.panel-head h2` rule (line 44):
+
+```css
+.panel-sub{margin:.25rem 0 0;font-size:11px;line-height:1.4;color:var(--muted)}
+```
+
+Note: keep the `()` in `notify()` but do not include any URL — the CSS/markup must stay free of `http(s)://` (Task constraint). The text uses a plain hyphen.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_notifications_panel_has_explanation" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manager/routers/dashboard_api.py manager/assets/dashboard_styles.css tests/manager_test/test_ui_redesign.py
+git commit -m "Dashboard: explain the Notifications panel with a subtitle"
+```
+
+---
+
+### Task 3: Make LOGS / DOCS read as buttons
+
+**Files:**
+- Modify: `manager/assets/dashboard_styles.css` (the `.lnk` rules at lines 90-95)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: restyled `.lnk` (markup unchanged — `get_service_log_link` / `get_service_docs_link` still emit `<a class="lnk">`).
+
+Current CSS (lines 88-95):
+
+```css
+/* ---------- service actions ---------- */
+.svc-actions{grid-area:actions;display:flex;gap:.4rem}
+.lnk{
+  font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--muted);text-decoration:none;border-bottom:1px solid transparent;padding:.1rem 0;
+  transition:color .15s,border-color .15s;
+}
+.lnk:hover{color:var(--accent);border-color:var(--accent)}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/manager_test/test_ui_redesign.py`:
+
+```python
+def test_service_links_look_like_buttons():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    # .lnk is now a bordered pill, not underline-on-hover text
+    assert ".lnk{" in css
+    lnk_block = css.split(".lnk{", 1)[1].split("}", 1)[0]
+    assert "border:1px solid" in lnk_block
+    assert "border-radius:" in lnk_block
+    # keyboard focus ring, matching .act
+    assert ".lnk:focus-visible{" in css
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_service_links_look_like_buttons" -v`
+Expected: FAIL (the current `.lnk` block has `border-bottom`, not `border:1px solid`, and no `:focus-visible`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace lines 90-95 of `manager/assets/dashboard_styles.css` with:
+
+```css
+.lnk{
+  font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--muted);text-decoration:none;
+  border:1px solid var(--line);border-radius:7px;padding:.34rem .6rem;
+  transition:color .15s,border-color .15s,background .15s;
+}
+.lnk:hover{color:var(--accent);border-color:var(--accent-dim);background:rgba(94,230,208,.06)}
+.lnk:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+```
+
+Note: this mirrors the existing `.act` button look (border + rounded + accent hover + focus ring) so the two LOGS/DOCS controls clearly read as clickable. `.svc-actions` already has `gap:.4rem`, which spaces the two pills correctly — no change needed there.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/python -m pytest "tests/manager_test/test_ui_redesign.py::test_service_links_look_like_buttons" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manager/assets/dashboard_styles.css tests/manager_test/test_ui_redesign.py
+git commit -m "Dashboard: style LOGS/DOCS as buttons with focus ring"
+```
+
+---
+
+### Task 4: Full guard-suite + lint pass
+
+**Files:**
+- No new code. Verification only.
+
+- [ ] **Step 1: Run the full UI guard suite**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -v`
+Expected: PASS (all existing tests + the three new ones). Confirms no earlier guard (e.g. `test_dashboard_layout_builds`, `test_dashboard_page_width_widened`, `test_notifications_panel_is_live`) regressed.
+
+- [ ] **Step 2: Lint the changed files**
+
+Run:
+```bash
+/home/kaveh/miniconda3/bin/python -m black --check manager/routers/dashboard_api.py tests/manager_test/test_ui_redesign.py
+/home/kaveh/miniconda3/bin/python -m flake8 manager/routers/dashboard_api.py tests/manager_test/test_ui_redesign.py
+/home/kaveh/miniconda3/bin/python -m pylint manager
+```
+Expected: black "would be left unchanged", flake8 no output, pylint 10.00/10. (CSS is not linted.) If black reports a reformat on `dashboard_api.py`, run it without `--check` to apply, then re-commit.
+
+- [ ] **Step 3: Commit any formatting fixup (only if Step 2 changed files)**
+
+```bash
+git add -A
+git commit -m "Dashboard polish: black formatting"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Widen Services / slim sidebar → Task 1 (`2.6fr 0.9fr`). ✓
+- Explain Notifications → Task 2 (`panel-sub` subtitle). ✓
+- LOGS/DOCS obvious → Task 3 (bordered buttons + focus ring). ✓
+- Fix top-heavy emptiness → Task 1 (`min-height:calc(100vh - 4rem)` + `margin-block:auto`). ✓
+- Testing section (guard-test asserts) → Tasks 1-3 each add one test; Task 4 runs the full suite + lint. ✓
+- Non-goals (no stats bar, no badges, no logs-view change, no backend) → respected; no task touches them. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full CSS/markup and exact commands. ✓
+
+**Type/string consistency:** The subtitle literal "Alerts services raise via the SDK notify() — info, warnings, critical." in Task 2's implementation matches the test's substring "Alerts services raise". The class names `.panel-sub`, `.lnk`, `.grid`, `.page` are used identically across implementation and tests. The `2.6fr 0.9fr` value (space-stripped to `2.6fr0.9fr` in tests) is consistent. ✓

--- a/docs/superpowers/plans/2026-06-29-logs-viewer-enhancements.md
+++ b/docs/superpowers/plans/2026-06-29-logs-viewer-enhancements.md
@@ -1,0 +1,518 @@
+# Logs Viewer Enhancements + Responsive Layout — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the logs view a full-screen responsive console with log export and in-log search (over full history), and let the dashboard use more of the screen.
+
+**Architecture:** Pure front-end + two tiny route-context additions; no backend changes. The shared `manager/templates/logs.html` (serves both per-service `/services/~logs/view` and manager `/logs/view`) gains a responsive flex layout, an Export button, and a Search box. Export/search fetch the full log via the existing endpoints with `tail=all`. Dashboard width is a one-line CSS change.
+
+**Tech Stack:** FastAPI + Jinja2 templates, Plotly Dash dashboard, vanilla JS + CSS (no build step, no libraries).
+
+**Spec:** `docs/superpowers/specs/2026-06-29-logs-viewer-enhancements-design.md`
+
+## Global Constraints
+
+- **No backend changes.** Export/search use existing endpoints: service `GET /services/~logs?name=&version=&tail=all`; manager `GET /logs/stream?tail=all`. The live tail keeps `tail=200`/`tail=400` + `follow=true`.
+- **Reuse the shared `manager/templates/logs.html`** — both log views get every feature.
+- **Self-contained** (no CDNs); use the existing design tokens (`var(--accent)`, `var(--ground)`, etc.).
+- **XSS-safe log rendering**: insert log text via `textContent` / `createTextNode` — never `innerHTML` on log content (search highlight uses `<mark>` element nodes around text nodes).
+- **Preserve the live tail**: streaming + Follow/auto-scroll/Jump-to-latest stay; new features layer on top.
+- **Dashboard width:** `max-width: 1600px` centered (not fully fluid).
+
+## File Structure
+
+- `manager/assets/dashboard_styles.css` — **(modify)** `.page` max-width 1180 → 1600.
+- `manager/templates/logs.html` — **(modify)** responsive flex layout CSS; toolbar gains Search + Export; JS for cancellable live stream, search (filter/highlight/count), export (download).
+- `manager/routers/service_api.py` — **(modify)** `service_logs_view`: add `full_url` + `export_basename` to context.
+- `manager/routers/logging_api.py` — **(modify)** `manager_logs_view`: add `full_url` + `export_basename` to context.
+- `tests/manager_test/test_ui_redesign.py` — **(modify)** add guard tests.
+
+Run tests with `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -v` from the repo root. Lint with `/home/kaveh/miniconda3/bin/python -m black --check <files>` and `/home/kaveh/miniconda3/bin/python -m pylint manager daeploy`.
+
+---
+
+## Task 1: Widen the dashboard
+
+**Files:**
+- Modify: `manager/assets/dashboard_styles.css:32`
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+- [ ] **Step 1: Write the failing test** (append to `tests/manager_test/test_ui_redesign.py`)
+
+```python
+def test_dashboard_page_width_widened():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    assert "max-width:1600px" in css
+    assert "max-width:1180px" not in css
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py::test_dashboard_page_width_widened -v`
+Expected: FAIL (current value is `1180px`).
+
+- [ ] **Step 3: Make the change** — in `manager/assets/dashboard_styles.css`, replace line 32:
+
+```css
+.page{max-width:1180px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
+```
+with:
+```css
+.page{max-width:1600px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
+```
+
+- [ ] **Step 4: Run it, expect PASS**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py::test_dashboard_page_width_widened -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manager/assets/dashboard_styles.css tests/manager_test/test_ui_redesign.py
+git commit -m "Widen dashboard page to 1600px"
+```
+
+---
+
+## Task 2: Responsive full-screen logs layout
+
+**Files:**
+- Modify: `manager/templates/logs.html` (CSS in the `<style>` block only)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+Make the page a flex column filling the viewport so the console grows/shrinks with the window instead of a fixed `60vh` card capped at `1180px`.
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+def test_logs_view_is_full_bleed():
+    html = TPL.joinpath("logs.html").read_text().replace(" ", "")
+    assert "max-width:1180px" not in html   # logs page no longer capped
+    assert "height:60vh" not in html         # console no longer fixed-height
+    assert "min-height:100vh" in html        # body fills viewport
+    assert "flex:1" in html                  # console/panel flex-fill
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py::test_logs_view_is_full_bleed -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Edit the CSS in `manager/templates/logs.html`.** Make these exact replacements inside `<style>`:
+
+(a) Replace:
+```css
+    body{background:var(--ground);color:var(--text);font-family:var(--sans);margin:0;}
+```
+with:
+```css
+    html,body{height:100%;}
+    body{background:var(--ground);color:var(--text);font-family:var(--sans);margin:0;
+      display:flex;flex-direction:column;min-height:100vh;}
+```
+
+(b) Replace:
+```css
+    .page{max-width:1180px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
+
+    .panel{
+      background:var(--surface);border:1px solid var(--line-soft);border-radius:16px;
+      overflow:hidden;
+    }
+```
+with:
+```css
+    .page{flex:1;min-height:0;display:flex;padding:1.2rem 1.6rem 1.6rem;}
+
+    .panel{
+      background:var(--surface);border:1px solid var(--line-soft);border-radius:16px;
+      overflow:hidden;flex:1;display:flex;flex-direction:column;min-height:0;width:100%;
+    }
+```
+
+(c) Replace:
+```css
+    .console-wrap{position:relative}
+    .console{
+      height:60vh;min-height:320px;overflow-y:auto;overflow-x:hidden;
+```
+with:
+```css
+    .console-wrap{position:relative;flex:1;min-height:0;display:flex;}
+    .console{
+      flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;
+```
+
+- [ ] **Step 4: Run it, expect PASS**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py::test_logs_view_is_full_bleed -v`
+Expected: PASS. Also confirm the page still renders:
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -k "logs_view or manager_logs_view" -v`
+Expected: PASS (existing render tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add manager/templates/logs.html tests/manager_test/test_ui_redesign.py
+git commit -m "Make the logs view a full-screen responsive console"
+```
+
+---
+
+## Task 3: Pass `full_url` + `export_basename` to both log views (and expose them in the template)
+
+**Files:**
+- Modify: `manager/routers/service_api.py` (`service_logs_view`)
+- Modify: `manager/routers/logging_api.py` (`manager_logs_view`)
+- Modify: `manager/templates/logs.html` (declare the two JS vars so the values render; Task 4 uses them)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+**Interfaces:**
+- Produces: two new template context values + JS globals consumed by Task 4 — `full_url` → `var FULL_URL` (the log endpoint with `tail=all`, for export/search) and `export_basename` → `var EXPORT_BASENAME` (download filename stem).
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+def test_service_logs_view_full_url_and_basename(test_client_logged_in):
+    r = test_client_logged_in.get("/services/~logs/view?name=demo&version=0.1.0")
+    assert r.status_code == 200
+    assert "/services/~logs?name=demo&version=0.1.0&tail=all" in r.text
+    assert 'EXPORT_BASENAME = "demo_v0.1.0"' in r.text
+
+
+def test_manager_logs_view_full_url_and_basename(test_client):
+    r = test_client.get("/logs/view")
+    assert r.status_code == 200
+    assert "/logs/stream?tail=all" in r.text
+    assert 'EXPORT_BASENAME = "manager"' in r.text
+```
+
+- [ ] **Step 2: Run them, expect FAIL**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -k "full_url_and_basename" -v`
+Expected: FAIL (neither the context values nor the `FULL_URL`/`EXPORT_BASENAME` JS vars exist yet).
+
+- [ ] **Step 3: Edit `manager/routers/service_api.py`** — replace the body of `service_logs_view`:
+
+```python
+@ROUTER.get("/~logs/view", response_class=HTMLResponse)
+def service_logs_view(request: Request, name: str, version: str):
+    """HTML view that streams a service's logs with a follow/auto-scroll toggle."""
+    base = f"/services/~logs?name={quote(name)}&version={quote(version)}"
+    return TEMPLATES.TemplateResponse(
+        request=request,
+        name="logs.html",
+        context={
+            "title": name,
+            "subtitle": f"v{version}",
+            "stream_url": f"{base}&follow=true&tail=200",
+            "full_url": f"{base}&tail=all",
+            "export_basename": f"{name}_v{version}",
+            "manager_version": get_manager_version(),
+        },
+    )
+```
+
+- [ ] **Step 4: Edit `manager/routers/logging_api.py`** — replace the body of `manager_logs_view`:
+
+```python
+@ROUTER.get("/view", response_class=HTMLResponse)
+def manager_logs_view(request: Request):
+    """HTML view that streams the manager logs with a follow/auto-scroll toggle.
+
+    \f
+    # noqa: DAR101,DAR201
+    """
+    return TEMPLATES.TemplateResponse(
+        request=request,
+        name="logs.html",
+        context={
+            "title": "manager",
+            "subtitle": f"v: {get_manager_version()}",
+            "stream_url": "/logs/stream?follow=true&tail=400",
+            "full_url": "/logs/stream?tail=all",
+            "export_basename": "manager",
+            "manager_version": get_manager_version(),
+        },
+    )
+```
+
+- [ ] **Step 5: Expose the values in `manager/templates/logs.html`.** In the `<script>` block, replace this single line:
+
+```html
+    var STREAM_URL = "{{ stream_url|safe }}";
+```
+with:
+```html
+    var STREAM_URL = "{{ stream_url|safe }}";
+    var FULL_URL   = "{{ full_url|safe }}";
+    var EXPORT_BASENAME = "{{ export_basename }}";
+```
+(These declarations are unused until Task 4 wires up export/search — harmless for now, and they make the rendered values testable.)
+
+- [ ] **Step 6: Run the tests, expect PASS**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -k "full_url_and_basename" -v`
+Expected: PASS. Also confirm existing render tests still pass:
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -k "logs_view or manager_logs_view" -v`
+Expected: PASS.
+
+- [ ] **Step 7: Black + commit**
+
+```bash
+/home/kaveh/miniconda3/bin/python -m black manager/routers/service_api.py manager/routers/logging_api.py
+git add manager/routers/service_api.py manager/routers/logging_api.py manager/templates/logs.html tests/manager_test/test_ui_redesign.py
+git commit -m "Pass full_url + export_basename to the log views"
+```
+
+---
+
+## Task 4: Logs toolbar — export + search
+
+**Files:**
+- Modify: `manager/templates/logs.html` (toolbar markup, CSS for search/mark, and the `<script>`)
+- Test: `tests/manager_test/test_ui_redesign.py`
+
+**Interfaces:**
+- Consumes: `stream_url`, `full_url`, `export_basename` (Task 3).
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+def test_logs_toolbar_has_search_and_export():
+    html = TPL.joinpath("logs.html").read_text()
+    assert 'id="searchBox"' in html
+    assert 'id="matchCount"' in html
+    assert 'id="exportBtn"' in html
+    assert "function runSearch" in html
+    assert "function startStream" in html        # cancellable live tail
+    assert "EXPORT_BASENAME" in html and "FULL_URL" in html
+    assert "a.download" in html                  # triggers a file download
+    assert "createTextNode" in html              # XSS-safe highlight
+```
+
+- [ ] **Step 2: Run it, expect FAIL**
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py::test_logs_toolbar_has_search_and_export -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the search/export CSS.** In `manager/templates/logs.html`, immediately after the `.logs-tools{...}` rule, add:
+
+```css
+    .searchbox{
+      background:var(--ground);border:1px solid var(--line);border-radius:8px;
+      color:var(--text);font-family:var(--mono);font-size:12px;padding:.35rem .6rem;width:210px;
+    }
+    .searchbox::placeholder{color:var(--faint)}
+    .searchbox:focus{outline:none;border-color:var(--accent-dim);box-shadow:0 0 0 3px rgba(94,230,208,.14)}
+    .match-count{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;color:var(--faint);min-width:64px}
+    .console mark{background:rgba(94,230,208,.28);color:var(--text);border-radius:2px;padding:0 1px}
+```
+
+- [ ] **Step 4: Replace the toolbar markup.** Replace this block:
+
+```html
+        <div class="logs-tools">
+          <span class="live-tag" id="liveTag"><span class="d"></span><span id="liveLabel">Live</span></span>
+          <label class="follow" title="Auto-scroll to newest logs">
+            <input type="checkbox" id="followBox" checked>
+            <span class="track" aria-hidden="true"></span><span class="flabel">Follow</span>
+          </label>
+        </div>
+```
+with:
+```html
+        <div class="logs-tools">
+          <input type="search" id="searchBox" class="searchbox" placeholder="Search logs…" autocomplete="off" aria-label="Search logs">
+          <span class="match-count" id="matchCount"></span>
+          <button class="act" id="exportBtn" type="button">Export</button>
+          <span class="live-tag" id="liveTag"><span class="d"></span><span id="liveLabel">Live</span></span>
+          <label class="follow" title="Auto-scroll to newest logs">
+            <input type="checkbox" id="followBox" checked>
+            <span class="track" aria-hidden="true"></span><span class="flabel">Follow</span>
+          </label>
+        </div>
+```
+
+- [ ] **Step 5: Replace the entire `<script> … </script>` block** (currently lines ~160–201) with:
+
+```html
+  <script>
+    var STREAM_URL = "{{ stream_url|safe }}";
+    var FULL_URL   = "{{ full_url|safe }}";
+    var EXPORT_BASENAME = "{{ export_basename }}";
+
+    var consoleEl=document.getElementById('console'),
+        followBox=document.getElementById('followBox'),
+        jumpBtn=document.getElementById('jumpBtn'),
+        liveTag=document.getElementById('liveTag'),
+        searchBox=document.getElementById('searchBox'),
+        matchCount=document.getElementById('matchCount'),
+        exportBtn=document.getElementById('exportBtn');
+
+    var searchActive=false, streamCtrl=null, searchTimer=null;
+
+    function nearBottom(){return consoleEl.scrollHeight-consoleEl.scrollTop-consoleEl.clientHeight<24;}
+    function setLive(on){liveTag.classList.toggle('paused',!on);document.getElementById('liveLabel').textContent=on?'Live':'Paused';}
+    function classify(line){var u=line.toUpperCase();
+      if(u.indexOf('ERROR')>-1||u.indexOf('CRITICAL')>-1)return'err';
+      if(u.indexOf('WARN')>-1)return'warn';return'info';}
+    function newRow(text){
+      var lvl=classify(text), row=document.createElement('div');
+      row.className='logline'+(lvl==='err'?' err':lvl==='warn'?' warn':'');
+      return row;
+    }
+    function appendLine(text){
+      if(!text)return;
+      var row=newRow(text);
+      row.textContent=text;            // textContent = safe, no XSS from log content
+      consoleEl.appendChild(row);
+      while(consoleEl.childElementCount>400)consoleEl.removeChild(consoleEl.firstChild);
+      if(followBox.checked)consoleEl.scrollTop=consoleEl.scrollHeight; else jumpBtn.classList.add('show');
+    }
+    function jumpToLatest(){followBox.checked=true;setLive(true);consoleEl.scrollTop=consoleEl.scrollHeight;jumpBtn.classList.remove('show');}
+
+    followBox.addEventListener('change',function(){setLive(followBox.checked);
+      if(followBox.checked){consoleEl.scrollTop=consoleEl.scrollHeight;jumpBtn.classList.remove('show');}});
+    consoleEl.addEventListener('scroll',function(){
+      if(searchActive)return;
+      if(followBox.checked&&!nearBottom()){followBox.checked=false;setLive(false);jumpBtn.classList.add('show');}
+      else if(!followBox.checked&&nearBottom()){jumpBtn.classList.remove('show');}});
+
+    // ---- live tail (cancellable) ----
+    async function startStream(){
+      if(streamCtrl)streamCtrl.abort();
+      streamCtrl=new AbortController();
+      consoleEl.textContent='';
+      followBox.checked=true; setLive(true); jumpBtn.classList.remove('show');
+      try{
+        var resp=await fetch(STREAM_URL,{headers:{'Accept':'text/plain'},signal:streamCtrl.signal});
+        var reader=resp.body.getReader(), dec=new TextDecoder(), buf='';
+        while(true){
+          var r=await reader.read(); if(r.done)break;
+          buf+=dec.decode(r.value,{stream:true});
+          var lines=buf.split('\n'); buf=lines.pop();
+          lines.forEach(appendLine);
+        }
+        if(buf)appendLine(buf);
+        setLive(false);
+      }catch(e){ if(e.name!=='AbortError'){appendLine('— log stream ended —');setLive(false);} }
+    }
+
+    // ---- search: filter to matching lines over full history ----
+    function appendMatch(text,term){
+      var row=newRow(text), lc=text.toLowerCase(), q=term.toLowerCase(), i=0, idx;
+      while((idx=lc.indexOf(q,i))>-1){
+        if(idx>i)row.appendChild(document.createTextNode(text.slice(i,idx)));
+        var m=document.createElement('mark'); m.textContent=text.slice(idx,idx+term.length); row.appendChild(m);
+        i=idx+term.length;
+      }
+      if(i<text.length)row.appendChild(document.createTextNode(text.slice(i)));
+      consoleEl.appendChild(row);
+    }
+    async function runSearch(term){
+      searchActive=true;
+      if(streamCtrl)streamCtrl.abort();
+      setLive(false); jumpBtn.classList.remove('show'); matchCount.textContent='…';
+      try{
+        var resp=await fetch(FULL_URL,{headers:{'Accept':'text/plain'}});
+        var text=await resp.text(), q=term.toLowerCase(), matches=0;
+        consoleEl.textContent='';
+        text.split('\n').forEach(function(line){
+          if(line && line.toLowerCase().indexOf(q)>-1){matches++; appendMatch(line,term);}
+        });
+        matchCount.textContent=matches+' match'+(matches===1?'':'es');
+      }catch(e){ matchCount.textContent='search failed'; }
+    }
+    function clearSearch(){ searchActive=false; matchCount.textContent=''; startStream(); }
+
+    searchBox.addEventListener('input',function(){
+      clearTimeout(searchTimer);
+      var term=searchBox.value;
+      searchTimer=setTimeout(function(){ if(term.trim()==='')clearSearch(); else runSearch(term); },250);
+    });
+
+    // ---- export: download full history as a .log file ----
+    exportBtn.addEventListener('click',async function(){
+      var old=exportBtn.textContent; exportBtn.textContent='…'; exportBtn.disabled=true;
+      try{
+        var resp=await fetch(FULL_URL,{headers:{'Accept':'text/plain'}});
+        var text=await resp.text();
+        var d=new Date(), p=function(n){return String(n).padStart(2,'0');};
+        var ts=''+d.getUTCFullYear()+p(d.getUTCMonth()+1)+p(d.getUTCDate())+'-'+p(d.getUTCHours())+p(d.getUTCMinutes())+p(d.getUTCSeconds());
+        var a=document.createElement('a');
+        a.href=URL.createObjectURL(new Blob([text],{type:'text/plain'}));
+        a.download=EXPORT_BASENAME+'_'+ts+'.log';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(function(){URL.revokeObjectURL(a.href);},1000);
+      }catch(e){ alert('Export failed: '+e); }
+      finally{ exportBtn.textContent=old; exportBtn.disabled=false; }
+    });
+
+    startStream();
+  </script>
+```
+
+- [ ] **Step 6: Run the full UI test module, expect PASS** (this also greens the Task 3 tests)
+
+Run: `./venv/bin/python -m pytest tests/manager_test/test_ui_redesign.py -v`
+Expected: all PASS (including `test_logs_toolbar_has_search_and_export`, `test_*_passes_full_url_and_basename`, and the pre-existing logs render tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add manager/templates/logs.html tests/manager_test/test_ui_redesign.py
+git commit -m "Add log export + search to the logs view toolbar"
+```
+
+---
+
+## Task 5: Verify live in the running manager
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Lint gates**
+
+Run: `/home/kaveh/miniconda3/bin/python -m black --check manager/ tests/manager_test/test_ui_redesign.py`
+Run: `/home/kaveh/miniconda3/bin/python -m pylint manager daeploy`
+Expected: black clean; pylint 10.00/10 (no new findings).
+
+- [ ] **Step 2: Build + run the manager from this branch**
+
+```bash
+docker build -t daeploy/manager:logsui .
+docker rm -f daeploy-manager 2>/dev/null
+docker run -d --name daeploy-manager -v /var/run/docker.sock:/var/run/docker.sock \
+  -v daeploy_data:/data -p 80:80 -p 443:443 -e DAEPLOY_AUTH_ENABLED=True \
+  -e DAEPLOY_HOST_NAME=localhost -e DAEPLOY_ADMIN_PASSWORD=admin123 daeploy/manager:logsui
+```
+
+- [ ] **Step 3: Visually verify** (browser at http://localhost, login admin/admin123)
+
+- Dashboard uses the wider layout (≈1600px).
+- Open a service's **Logs** (or `/logs/view`): the console **fills the window**; resize the browser and confirm it grows/shrinks.
+- **Export** downloads a `‹name›_v‹version›_‹timestamp›.log` (manager → `manager_‹timestamp›.log`) containing the full log.
+- **Search**: type a term → only matching lines show, term highlighted, count shown ("N matches"), Live flips to Paused. Clear the box → live tail resumes (Live, auto-scroll).
+
+- [ ] **Step 4: Tear down**
+
+```bash
+docker rm -f daeploy-manager
+```
+
+- [ ] **Step 5: Commit any verification fixes** (only if needed)
+
+```bash
+git add -A && git commit -m "Logs viewer: verification fixes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** A responsive logs view → Task 2. B responsive dashboard → Task 1. C export (full history, `.log`, per-view) → Task 3 (`full_url`/`export_basename`) + Task 4 (button + JS). D search (full history, filter-to-matches, highlight, count, pause Follow, clear-resumes) → Task 3 + Task 4. No-backend-changes → only routes (context) + template + CSS touched. Reuse shared `logs.html` → yes. XSS-safe → `textContent`/`createTextNode` asserted in Task 4. Toolbar layout → Task 4 markup. Verify live → Task 5.
+
+**Placeholder scan:** every code step shows complete code; commands have expected output; no TBD/TODO. Task 3's tests intentionally green after Task 4 — called out explicitly, not a hidden gap.
+
+**Type/name consistency:** context keys `stream_url`/`full_url`/`export_basename`/`title`/`subtitle`/`manager_version` match between the routes (Task 3) and the template `{{ }}` + JS vars `STREAM_URL`/`FULL_URL`/`EXPORT_BASENAME` (Task 4). Element ids `searchBox`/`matchCount`/`exportBtn`/`console`/`followBox`/`liveTag`/`liveLabel`/`jumpBtn` are consistent between the markup (Step 4) and the script (Step 5). `startStream`/`runSearch`/`clearSearch`/`appendMatch`/`appendLine`/`jumpToLatest` defined and referenced consistently; `jumpToLatest` stays a global (used by inline `onclick`).

--- a/docs/superpowers/specs/2026-06-29-dashboard-main-page-polish-design.md
+++ b/docs/superpowers/specs/2026-06-29-dashboard-main-page-polish-design.md
@@ -1,0 +1,97 @@
+# Dashboard main-page polish — design
+
+**Date:** 2026-06-29
+**Branch:** `dashboard-main-page-polish` → `develop`
+**Scope:** Frontend-only polish of the manager dashboard (the Dash "main page"). No backend, no API, no new data. The logs *view* page is explicitly out of scope (unchanged).
+
+## Problem
+
+On a wide monitor the dashboard reads top-heavy and sparse: content hugs the top with a large empty void below. Secondary issues raised by the user:
+
+1. The **Services** panel feels too narrow relative to its importance.
+2. The **Notifications** panel is unexplained — an empty "No notifications." reads as "what is this section?" rather than "nothing wrong."
+3. The per-service **LOGS / DOCS** links are not obviously clickable (tiny uppercase text, underline only on hover).
+
+## Goals
+
+- Make Services the clear hero (wider) and Notifications a slim, self-explanatory right rail.
+- Remove the top-heavy empty void without inventing new content.
+- Make LOGS / DOCS read as actionable controls.
+
+## Non-goals (YAGNI)
+
+- No new stats/summary bar, service counts, or notification badges.
+- No structural rewrite of the Dash layout or callbacks.
+- No change to the logs view page, login, or any backend/endpoint.
+
+## Design
+
+All changes are in `manager/routers/dashboard_api.py` (layout markup) and
+`manager/assets/dashboard_styles.css` (styling). The design tokens in
+`tokens.css` are reused; no new colors.
+
+### 1. Widen Services, slim the sidebar
+`.grid` columns change from `1.85fr 1fr` to **`2.6fr 0.9fr`**. Services gets
+the dominant width; Notifications becomes a narrow rail. The existing
+`@media (max-width:760px)` rule already collapses to a single column, so the
+mobile path is unchanged.
+
+### 2. Explain Notifications
+Add a one-line muted subtitle beneath the "Notifications" heading in the panel
+head, e.g.:
+
+> Alerts services raise via the SDK `notify()` — info, warnings, critical.
+
+Implemented as a small `<p class="panel-sub">` element in the Notifications
+panel head. A new `.panel-sub` style (muted, ~11px) renders it quietly. The
+Services panel head is left as-is (no subtitle needed).
+
+### 3. Make LOGS / DOCS obvious
+Restyle the per-service `.lnk` links to small bordered pill buttons that reuse
+the look of the existing `.act` controls (1px border, rounded, accent on
+hover) instead of underline-on-hover text. Keep them compact so the row height
+is unchanged. Markup stays the same (`<a class="lnk">`); only CSS changes,
+plus an accessible `:focus-visible` ring to match `.act`.
+
+### 4. Fix top-heavy emptiness
+Vertically center the page content when it is shorter than the viewport, while
+falling back to normal top-aligned scrolling once there are enough services to
+fill the screen. Implemented with a viewport-relative min-height plus flex
+auto-margins (which center but never clip):
+
+- The dashboard is a Dash app: the layout is mounted inside Dash's own wrapper
+  divs, so a `body { flex }` chain would not reliably reach `.page`. Instead,
+  size `.page` directly against the viewport.
+- `.page` gets `min-height:calc(100vh - 4rem)` (the `4rem` budgets for the top
+  banner), `box-sizing:border-box` (there is no global reset, and `.page` has
+  padding), and `display:flex; flex-direction:column`. `vh` is
+  viewport-relative regardless of ancestor heights, so this needs no changes to
+  body or the Dash wrappers.
+- The inner `.grid` gets `margin-block:auto`. Auto margins center the grid
+  vertically when there is spare room; when the grid is taller than the
+  available space the margins collapse to zero and the page scrolls normally —
+  no overflow clipping.
+
+This removes the void below the cards on a tall screen without adding content.
+
+## Testing
+
+Extend the existing guard tests in `tests/manager_test/test_ui_redesign.py`
+(asset/markup string asserts, consistent with the current approach):
+
+- Notifications subtitle text (`panel-sub`) is present in the rendered layout.
+- `.panel-sub` style exists in `dashboard_styles.css`.
+- `.lnk` is styled as a bordered button (border + border-radius) and has a
+  `:focus-visible` rule.
+- `.grid` uses the new `2.6fr 0.9fr` template.
+- Vertical-fill rule present (`.page` has `min-height:calc(100vh - 4rem)` and
+  `.grid` has `margin-block:auto`).
+
+Run locally before pushing: `black --check`, `flake8`, `pylint manager`, and
+`pytest tests/manager_test/test_ui_redesign.py`.
+
+## Rollout
+
+Frontend-only; ships in the next `develop` → `master` release alongside the
+logs-viewer work. The live server picks it up on the next manager image build
+(connectors untouched).

--- a/docs/superpowers/specs/2026-06-29-logs-viewer-enhancements-design.md
+++ b/docs/superpowers/specs/2026-06-29-logs-viewer-enhancements-design.md
@@ -1,0 +1,66 @@
+# Logs Viewer Enhancements + Responsive Layout — Design Spec
+
+**Date:** 2026-06-29
+**Branch:** `logs-viewer-enhancements` (off `develop`)
+**Status:** Approved design, pending spec review → implementation plan
+**Builds on:** the 1.4.0 UI redesign ([[daeploy-ui-redesign]]); same FastAPI + Dash + self-contained-assets stack.
+
+## Goal
+
+Make the redesigned UI use the screen better and turn the logs view into a real log console:
+
+- **A. Responsive logs view** — fills the viewport (height + width) instead of a fixed `60vh` / `1180px` card.
+- **B. Responsive dashboard** — uses much more of the screen instead of a `1180px` centered column.
+- **C. Export logs** — download a service's (or the manager's) full log as a file.
+- **D. Search logs** — find text across the full log, filtered to matching lines.
+
+## Constraints
+
+- **Reuse the shared `manager/templates/logs.html`** — it already serves both per-service (`/services/~logs/view`) and manager (`/logs/view`) logs, so both get every feature here.
+- **No backend changes.** The existing endpoints already support what's needed: `/services/~logs?...&tail=all&follow=false` and `/logs/stream?tail=all&follow=false` return the full log. Export and search are client-side fetches against these.
+- **Self-contained** (no CDNs), consistent with the redesign tokens/theme.
+- **Preserve the live tail** — streaming + the Follow/auto-scroll/jump behavior stay; the new features layer on top.
+
+## A. Responsive logs view
+
+- Drop `.page { max-width:1180px }` for the logs page → full width with modest side padding.
+- Lay the page out as a **flex column filling the viewport**: top bar + `.logs-head` toolbar take natural height; `.console` gets `flex:1` (and `min-height:0`) so it grows/shrinks with the window and screen resolution. Remove the fixed `height:60vh`.
+- Buffer cap stays for the *live tail* (keep DOM light); search/export bypass it by fetching the full log.
+
+## B. Responsive dashboard
+
+- In `manager/assets/dashboard_styles.css`, change `.page { max-width:1180px }` → `max-width:1600px` (still centered, generous side padding). The services/notifications `.grid` then uses far more width. (Decision: capped 1600px centered, not fully fluid — avoids absurd line lengths on ultrawide.)
+
+## C. Export logs to a file
+
+- An **Export** button in the logs toolbar (`.logs-tools`).
+- On click: fetch the **full** log (`full_url`, i.e. the endpoint with `tail=all&follow=false`), build a `Blob`, and trigger a download.
+- **Filename:** `‹title›_‹subtitle›_‹UTC-timestamp›.log` for services (e.g. `status_code_v0.1.0_20260629-153012.log`); `manager_‹UTC-timestamp›.log` for manager logs. Plain text, `.log`.
+- Pure client-side (`fetch` → `Blob` → object URL → `<a download>`). Works on both views.
+
+## D. Search (filter to matches)
+
+- A **search input** in the toolbar, with a **match-count** label.
+- On input (debounced ~250 ms) with a non-empty term: fetch the full log once (`full_url`), render **only lines containing the term** (case-insensitive substring), **highlight** the matched substring, and show the count (e.g. `37 matches` / `No matches`).
+- **Follow auto-pauses** while a search is active (you're viewing history, not the tail).
+- **Clearing** the box restores the **live tail** by clearing the console and restarting the live-tail stream (re-fetch `stream_url`, `tail=200&follow=true`), with Follow re-enabled.
+- Highlighting uses DOM text nodes + a `<mark>`-style span (never `innerHTML` on log content — XSS-safe, consistent with the existing `textContent` rendering).
+- No regex / no case toggle for now (YAGNI); case-insensitive substring only.
+
+## Toolbar layout
+
+`[🔍 search…] [37 matches] · [Export] · [● Live] [Follow ▢]` — search + count on the left of the tools group, Export next, then the existing Live indicator + Follow toggle.
+
+## Implementation outline (for the plan)
+
+1. **Routes** (`manager/routers/service_api.py::service_logs_view`, `manager/routers/logging_api.py::manager_logs_view`): pass one extra context value, **`full_url`** (the same endpoint as `stream_url` but `tail=all&follow=false`), e.g. service `/services/~logs?name=..&version=..&tail=all`; manager `/logs/stream?tail=all`.
+2. **`manager/templates/logs.html`**: add the search input + match-count + Export button to `.logs-tools`; CSS for the full-bleed flex layout, the search box, and `<mark>` highlight; JS for export (fetch full → download), search (fetch full → filter/highlight/count, pause follow), and clear-search (resume tail).
+3. **`manager/assets/dashboard_styles.css`**: `.page` max-width 1180 → 1600.
+4. **Tests** (`tests/manager_test/test_ui_redesign.py`): assert `logs.html` has the search input, match-count, and Export elements; assert the view routes include `full_url` (tail=all); assert the logs `.page` is no longer capped at 1180 and the dashboard `.page` is 1600.
+5. **Verify** live in the running manager: resize (console fills viewport), export downloads a `.log`, search filters with a count, clear resumes the tail; dashboard uses the wider layout.
+
+## Risks / notes
+
+- Fetching `tail=all` on a very large log transfers the whole thing for export/search — acceptable and expected per the "full history" decision; the live tail still uses `tail=200`.
+- Search refetches the full log on each new term (debounced); fine for typical logs. Could cache the fetched full log per session as a later optimization (not now).
+- This is a separate feature branch off `develop`; ships in a later release (e.g. 1.4.1 / 1.5.0), independent of the in-flight 1.4.0 PyPI publish.

--- a/manager/assets/dashboard_styles.css
+++ b/manager/assets/dashboard_styles.css
@@ -29,8 +29,19 @@ a{color:inherit;text-decoration:none;}
 .act.danger:hover{color:var(--crit);border-color:var(--crit)}
 
 /* ---------- page / grid ---------- */
-.page{max-width:1180px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
-.grid{display:grid;grid-template-columns:1.85fr 1fr;gap:1.4rem;align-items:start}
+.page{
+  max-width:1600px;margin:0 auto;padding:1.8rem 1.6rem 4rem;
+  box-sizing:border-box;min-height:calc(100vh - 4rem);
+  display:flex;flex-direction:column;
+}
+.grid{
+  display:grid;grid-template-columns:2.6fr 0.9fr;gap:1.4rem;align-items:start;
+  width:100%;
+  /* Bias content toward the top with a small, capped gap below the banner —
+     the remaining viewport slack falls below, so a few short rows no longer
+     float to mid-screen with a large empty band above. */
+  margin-top:clamp(0.5rem, 5vh, 2.5rem);
+}
 
 /* ---------- panels ---------- */
 .panel{
@@ -42,6 +53,7 @@ a{color:inherit;text-decoration:none;}
   padding:1rem 1.2rem .85rem;border-bottom:1px solid var(--line-soft);
 }
 .panel-head h2{font-size:.82rem;letter-spacing:.04em;font-weight:600;margin:0}
+.panel-sub{margin:.25rem 0 0;font-size:11px;line-height:1.4;color:var(--muted)}
 .count{font-family:var(--mono);font-size:11px;color:var(--faint)}
 
 /* ---------- service rows ---------- */
@@ -50,7 +62,7 @@ a{color:inherit;text-decoration:none;}
   grid-template-columns:1.3fr .7fr auto;
   grid-template-areas:"id state actions";
   align-items:center;gap:.8rem;
-  padding:.95rem 1.2rem;border-bottom:1px solid var(--line-soft);
+  padding:.5rem 1.2rem;border-bottom:1px solid var(--line-soft);
   transition:background .15s;
 }
 .svc:last-child{border-bottom:none}
@@ -88,11 +100,13 @@ a{color:inherit;text-decoration:none;}
 /* ---------- service actions ---------- */
 .svc-actions{grid-area:actions;display:flex;gap:.4rem}
 .lnk{
-  font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;
-  color:var(--muted);text-decoration:none;border-bottom:1px solid transparent;padding:.1rem 0;
-  transition:color .15s,border-color .15s;
+  font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--muted);text-decoration:none;
+  border:1px solid var(--line);border-radius:7px;padding:.34rem .6rem;
+  transition:color .15s,border-color .15s,background .15s;
 }
-.lnk:hover{color:var(--accent);border-color:var(--accent)}
+.lnk:hover{color:var(--accent);border-color:var(--accent-dim);background:rgba(94,230,208,.06)}
+.lnk:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 
 /* ---------- notifications ---------- */
 .note{

--- a/manager/routers/dashboard_api.py
+++ b/manager/routers/dashboard_api.py
@@ -336,7 +336,19 @@ app.layout = html.Div(
                             children=[
                                 html.Div(
                                     className="panel-head",
-                                    children=[html.H2("Notifications")],
+                                    children=[
+                                        html.Div(
+                                            [
+                                                html.H2("Notifications"),
+                                                html.P(
+                                                    "Alerts services raise via the SDK"
+                                                    " notify() — info, warnings,"
+                                                    " critical.",
+                                                    className="panel-sub",
+                                                ),
+                                            ]
+                                        )
+                                    ],
                                 ),
                                 html.Div(
                                     id="notifications-content",

--- a/manager/routers/logging_api.py
+++ b/manager/routers/logging_api.py
@@ -69,6 +69,8 @@ def manager_logs_view(request: Request):
             "title": "manager",
             "subtitle": f"v: {get_manager_version()}",
             "stream_url": "/logs/stream?follow=true&tail=400",
+            "full_url": "/logs/stream",
+            "export_basename": "manager",
             "manager_version": get_manager_version(),
         },
     )

--- a/manager/routers/service_api.py
+++ b/manager/routers/service_api.py
@@ -332,17 +332,16 @@ def assign_main_service(service: BaseService):
 @ROUTER.get("/~logs/view", response_class=HTMLResponse)
 def service_logs_view(request: Request, name: str, version: str):
     """HTML view that streams a service's logs with a follow/auto-scroll toggle."""
-    stream_url = (
-        f"/services/~logs?name={quote(name)}&version={quote(version)}"
-        "&follow=true&tail=200"
-    )
+    base = f"/services/~logs?name={quote(name)}&version={quote(version)}"
     return TEMPLATES.TemplateResponse(
         request=request,
         name="logs.html",
         context={
             "title": name,
             "subtitle": f"v{version}",
-            "stream_url": stream_url,
+            "stream_url": f"{base}&follow=true&tail=200",
+            "full_url": base,
+            "export_basename": f"{name}_v{version}",
             "manager_version": get_manager_version(),
         },
     )

--- a/manager/templates/logs.html
+++ b/manager/templates/logs.html
@@ -6,7 +6,9 @@
   <link rel="icon" href="/assets/favicon.ico">
   <link rel="stylesheet" href="/assets/tokens.css">
   <style>
-    body{background:var(--ground);color:var(--text);font-family:var(--sans);margin:0;}
+    html,body{height:100%;}
+    body{background:var(--ground);color:var(--text);font-family:var(--sans);margin:0;
+      display:flex;flex-direction:column;min-height:100vh;}
 
     /* ---------- top bar ---------- */
     .top{
@@ -33,12 +35,13 @@
     }
     .act:hover{color:var(--text);border-color:var(--accent-dim)}
     .act.danger:hover{color:var(--crit);border-color:var(--crit)}
+    .act:focus-visible{outline:2px solid var(--accent);outline-offset:2px;}
 
-    .page{max-width:1180px;margin:0 auto;padding:1.8rem 1.6rem 4rem}
+    .page{flex:1;min-height:0;display:flex;padding:1.2rem 1.6rem 1.6rem;}
 
     .panel{
       background:var(--surface);border:1px solid var(--line-soft);border-radius:16px;
-      overflow:hidden;
+      overflow:hidden;flex:1;display:flex;flex-direction:column;min-height:0;width:100%;
     }
 
     /* ---------- service status dot ---------- */
@@ -64,6 +67,14 @@
     .live-tag.paused{color:var(--faint)}
     .live-tag.paused .d{background:var(--faint);box-shadow:none;animation:none}
     .logs-tools{display:flex;align-items:center;gap:.9rem}
+    .searchbox{
+      background:var(--ground);border:1px solid var(--line);border-radius:8px;
+      color:var(--text);font-family:var(--mono);font-size:12px;padding:.35rem .6rem;width:210px;
+    }
+    .searchbox::placeholder{color:var(--faint)}
+    .searchbox:focus{outline:none;border-color:var(--accent-dim);box-shadow:0 0 0 3px rgba(94,230,208,.14)}
+    .match-count{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;color:var(--faint);min-width:64px}
+    .console mark{background:rgba(94,230,208,.28);color:var(--text);border-radius:2px;padding:0 1px}
 
     /* follow switch */
     .follow{display:inline-flex;align-items:center;gap:.55rem;cursor:pointer;user-select:none}
@@ -84,9 +95,9 @@
     }
     .follow input:checked ~ .flabel{color:var(--text)}
 
-    .console-wrap{position:relative}
+    .console-wrap{position:relative;flex:1;min-height:0;display:flex;}
     .console{
-      height:60vh;min-height:320px;overflow-y:auto;overflow-x:hidden;
+      flex:1;min-height:0;overflow-y:auto;overflow-x:hidden;
       font-family:var(--mono);font-size:12.5px;line-height:1.7;
       padding:.6rem 0;background:
         linear-gradient(180deg,rgba(94,230,208,.025),transparent 120px);
@@ -144,6 +155,9 @@
         <div class="ctx"><span class="sdot run live"></span>
           <span class="name">{{ title }}</span><span class="ver">{{ subtitle }}</span></div>
         <div class="logs-tools">
+          <input type="search" id="searchBox" class="searchbox" placeholder="Search logs…" autocomplete="off" aria-label="Search logs">
+          <span class="match-count" id="matchCount"></span>
+          <button class="act" id="exportBtn" type="button">Export</button>
           <span class="live-tag" id="liveTag"><span class="d"></span><span id="liveLabel">Live</span></span>
           <label class="follow" title="Auto-scroll to newest logs">
             <input type="checkbox" id="followBox" checked>
@@ -159,34 +173,54 @@
   </div>
   <script>
     var STREAM_URL = "{{ stream_url|safe }}";
+    var FULL_URL   = "{{ full_url|safe }}";
+    var EXPORT_BASENAME = "{{ export_basename }}";
+
     var consoleEl=document.getElementById('console'),
         followBox=document.getElementById('followBox'),
         jumpBtn=document.getElementById('jumpBtn'),
-        liveTag=document.getElementById('liveTag');
+        liveTag=document.getElementById('liveTag'),
+        searchBox=document.getElementById('searchBox'),
+        matchCount=document.getElementById('matchCount'),
+        exportBtn=document.getElementById('exportBtn');
+
+    var searchActive=false, streamCtrl=null, searchTimer=null, searchCtrl=null;
+
     function nearBottom(){return consoleEl.scrollHeight-consoleEl.scrollTop-consoleEl.clientHeight<24;}
     function setLive(on){liveTag.classList.toggle('paused',!on);document.getElementById('liveLabel').textContent=on?'Live':'Paused';}
     function classify(line){var u=line.toUpperCase();
       if(u.indexOf('ERROR')>-1||u.indexOf('CRITICAL')>-1)return'err';
       if(u.indexOf('WARN')>-1)return'warn';return'info';}
-    function appendLine(text){
-      if(!text)return;
+    function newRow(text){
       var lvl=classify(text), row=document.createElement('div');
       row.className='logline'+(lvl==='err'?' err':lvl==='warn'?' warn':'');
+      return row;
+    }
+    function appendLine(text){
+      if(!text)return;
+      var row=newRow(text);
       row.textContent=text;            // textContent = safe, no XSS from log content
       consoleEl.appendChild(row);
       while(consoleEl.childElementCount>400)consoleEl.removeChild(consoleEl.firstChild);
       if(followBox.checked)consoleEl.scrollTop=consoleEl.scrollHeight; else jumpBtn.classList.add('show');
     }
     function jumpToLatest(){followBox.checked=true;setLive(true);consoleEl.scrollTop=consoleEl.scrollHeight;jumpBtn.classList.remove('show');}
+
     followBox.addEventListener('change',function(){setLive(followBox.checked);
       if(followBox.checked){consoleEl.scrollTop=consoleEl.scrollHeight;jumpBtn.classList.remove('show');}});
     consoleEl.addEventListener('scroll',function(){
+      if(searchActive)return;
       if(followBox.checked&&!nearBottom()){followBox.checked=false;setLive(false);jumpBtn.classList.add('show');}
       else if(!followBox.checked&&nearBottom()){jumpBtn.classList.remove('show');}});
-    // stream the real endpoint
-    (async function(){
+
+    // ---- live tail (cancellable) ----
+    async function startStream(){
+      if(streamCtrl)streamCtrl.abort();
+      streamCtrl=new AbortController();
+      consoleEl.textContent='';
+      followBox.checked=true; setLive(true); jumpBtn.classList.remove('show');
       try{
-        var resp=await fetch(STREAM_URL,{headers:{'Accept':'text/plain'}});
+        var resp=await fetch(STREAM_URL,{headers:{'Accept':'text/plain'},signal:streamCtrl.signal});
         var reader=resp.body.getReader(), dec=new TextDecoder(), buf='';
         while(true){
           var r=await reader.read(); if(r.done)break;
@@ -196,8 +230,63 @@
         }
         if(buf)appendLine(buf);
         setLive(false);
-      }catch(e){appendLine('— log stream ended —');setLive(false);}
-    })();
+      }catch(e){ if(e.name!=='AbortError'){appendLine('— log stream ended —');setLive(false);} }
+    }
+
+    // ---- search: filter to matching lines over full history ----
+    function appendMatch(text,term){
+      var row=newRow(text), lc=text.toLowerCase(), q=term.toLowerCase(), i=0, idx;
+      while((idx=lc.indexOf(q,i))>-1){
+        if(idx>i)row.appendChild(document.createTextNode(text.slice(i,idx)));
+        var m=document.createElement('mark'); m.textContent=text.slice(idx,idx+term.length); row.appendChild(m);
+        i=idx+term.length;
+      }
+      if(i<text.length)row.appendChild(document.createTextNode(text.slice(i)));
+      consoleEl.appendChild(row);
+    }
+    async function runSearch(term){
+      searchActive=true;
+      if(streamCtrl)streamCtrl.abort();
+      if(searchCtrl)searchCtrl.abort(); searchCtrl=new AbortController();
+      setLive(false); jumpBtn.classList.remove('show'); matchCount.textContent='…';
+      try{
+        var resp=await fetch(FULL_URL,{headers:{'Accept':'text/plain'},signal:searchCtrl.signal});
+        var text=await resp.text();
+        if(!searchActive)return;
+        var q=term.toLowerCase(), matches=0;
+        consoleEl.textContent='';
+        text.split('\n').forEach(function(line){
+          if(line && line.toLowerCase().indexOf(q)>-1){matches++; appendMatch(line,term);}
+        });
+        matchCount.textContent=matches+' match'+(matches===1?'':'es');
+      }catch(e){ if(e.name!=='AbortError')matchCount.textContent='search failed'; }
+    }
+    function clearSearch(){ searchActive=false; matchCount.textContent=''; if(searchCtrl)searchCtrl.abort(); startStream(); }
+
+    searchBox.addEventListener('input',function(){
+      clearTimeout(searchTimer);
+      var term=searchBox.value;
+      searchTimer=setTimeout(function(){ if(term.trim()==='')clearSearch(); else runSearch(term); },250);
+    });
+
+    // ---- export: download full history as a .log file ----
+    exportBtn.addEventListener('click',async function(){
+      var old=exportBtn.textContent; exportBtn.textContent='…'; exportBtn.disabled=true;
+      try{
+        var resp=await fetch(FULL_URL,{headers:{'Accept':'text/plain'}});
+        var text=await resp.text();
+        var d=new Date(), p=function(n){return String(n).padStart(2,'0');};
+        var ts=''+d.getUTCFullYear()+p(d.getUTCMonth()+1)+p(d.getUTCDate())+'-'+p(d.getUTCHours())+p(d.getUTCMinutes())+p(d.getUTCSeconds());
+        var a=document.createElement('a');
+        a.href=URL.createObjectURL(new Blob([text],{type:'text/plain'}));
+        a.download=EXPORT_BASENAME+'_'+ts+'.log';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(function(){URL.revokeObjectURL(a.href);},1000);
+      }catch(e){ alert('Export failed: '+e); }
+      finally{ exportBtn.textContent=old; exportBtn.disabled=false; }
+    });
+
+    startStream();
   </script>
 </body>
 </html>

--- a/tests/manager_test/test_ui_redesign.py
+++ b/tests/manager_test/test_ui_redesign.py
@@ -125,3 +125,89 @@ def test_manager_logs_view_route(test_client):
     assert 'id="console"' in body and 'id="followBox"' in body
     assert "/logs/stream?follow=true" in body
     assert "/assets/tokens.css" in body
+
+
+def test_dashboard_page_width_widened():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    assert "max-width:1600px" in css
+    assert "max-width:1180px" not in css
+
+
+def test_logs_view_is_full_bleed():
+    html = TPL.joinpath("logs.html").read_text().replace(" ", "")
+    assert "max-width:1180px" not in html  # logs page no longer capped
+    assert "height:60vh" not in html  # console no longer fixed-height
+    assert "min-height:100vh" in html  # body fills viewport
+    assert "flex:1" in html  # console/panel flex-fill
+
+
+def test_service_logs_view_full_url_and_basename(test_client_logged_in):
+    r = test_client_logged_in.get("/services/~logs/view?name=demo&version=0.1.0")
+    assert r.status_code == 200
+    # full_url omits tail so the endpoint receives tail=None -> Docker "all".
+    # Passing the literal tail=all 422s (the param is typed int).
+    assert '"/services/~logs?name=demo&version=0.1.0"' in r.text
+    assert "tail=all" not in r.text
+    assert 'EXPORT_BASENAME = "demo_v0.1.0"' in r.text
+
+
+def test_manager_logs_view_full_url_and_basename(test_client):
+    r = test_client.get("/logs/view")
+    assert r.status_code == 200
+    assert '"/logs/stream"' in r.text
+    assert "tail=all" not in r.text
+    assert 'EXPORT_BASENAME = "manager"' in r.text
+
+
+def test_logs_toolbar_has_search_and_export():
+    html = TPL.joinpath("logs.html").read_text()
+    assert 'id="searchBox"' in html
+    assert 'id="matchCount"' in html
+    assert 'id="exportBtn"' in html
+    assert "function runSearch" in html
+    assert "function startStream" in html  # cancellable live tail
+    assert "EXPORT_BASENAME" in html and "FULL_URL" in html
+    assert "a.download" in html  # triggers a file download
+    assert "createTextNode" in html  # XSS-safe highlight
+
+
+def test_dashboard_grid_widens_services_and_fills_viewport():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    # Services hero is wider than the slim Notifications rail
+    assert "grid-template-columns:2.6fr0.9fr" in css
+    assert "grid-template-columns:1.85fr1fr" not in css
+    # Page fills the viewport height (minus the banner); content is biased to
+    # the top with a small, capped gap (not centered, which floated the panels
+    # to mid-screen and left a large gap above on tall monitors).
+    assert "min-height:calc(100vh-4rem)" in css
+    assert "box-sizing:border-box" in css
+    assert "margin-block:auto" not in css  # no full-height vertical centering
+    assert "margin-top:clamp(" in css  # small capped top gap on .grid
+
+
+def test_notifications_panel_has_explanation():
+    from manager.routers import dashboard_api
+
+    layout = str(dashboard_api.app.layout)
+    assert "Alerts services raise" in layout  # one-line description of the panel
+    css = (ASSETS / "dashboard_styles.css").read_text()
+    assert ".panel-sub" in css
+
+
+def test_service_rows_are_compact():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    assert ".svc{" in css
+    svc_block = css.split(".svc{", 1)[1].split("}", 1)[0]
+    # tight vertical row padding so more services fit without scrolling
+    assert "padding:.5rem1.2rem" in svc_block
+
+
+def test_service_links_look_like_buttons():
+    css = (ASSETS / "dashboard_styles.css").read_text().replace(" ", "")
+    # .lnk is now a bordered pill, not underline-on-hover text
+    assert ".lnk{" in css
+    lnk_block = css.split(".lnk{", 1)[1].split("}", 1)[0]
+    assert "border:1pxsolid" in lnk_block
+    assert "border-radius:" in lnk_block
+    # keyboard focus ring, matching .act
+    assert ".lnk:focus-visible{" in css

--- a/tests/sdk_test/daeploy_test.py
+++ b/tests/sdk_test/daeploy_test.py
@@ -735,28 +735,44 @@ def test_edge_case_type_storing(database):
     assert db.read_from_ts("my.normal.float")[-1].value == 10.10
 
 
-def test_read_timerange(database):
+def test_read_timerange(database, monkeypatch):
+
+    # Root cause of this test's historic flakiness: clean_database() is the only
+    # code path that deletes rows, and it re-reads DAEPLOY_SERVICE_DB_TABLE_LIMIT
+    # on every call. A leaked periodic clean (e.g. with the "1seconds" limit that
+    # db_limit_second sets) trims the OLDEST rows as they age past the limit,
+    # mid-test — so successive reads disagreed and a wider window could return
+    # FEWER rows than a narrower one (200 == 195/191/...). Pin a huge limit for
+    # the duration of this test so any concurrent clean is a no-op for our data.
+    monkeypatch.setenv("DAEPLOY_SERVICE_DB_TABLE_LIMIT", "36500days")
 
     before = datetime.datetime.utcnow()
-    mid = None
 
-    for i in range(200):
-        db.write_to_ts("float", float(i), datetime.datetime.utcnow())
-        if i == 100:
-            mid = datetime.datetime.utcnow()
+    # Explicit, strictly-increasing timestamps: the timestamp column is the
+    # table's primary key, so repeated utcnow() within one microsecond would
+    # collide on the PK.
+    timestamps = [before + datetime.timedelta(milliseconds=i + 1) for i in range(200)]
+    mid = timestamps[100]
+
+    for i, timestamp in enumerate(timestamps):
+        db.write_to_ts("float", float(i), timestamp)
     await_database_queue()
 
-    after = datetime.datetime.utcnow()
+    after = timestamps[-1] + datetime.timedelta(milliseconds=1)
 
-    # Check that default values behave according to expectations
+    # Check the from_time/to_time defaults: open-ended from_time/to_time default
+    # to datetime.min / utcnow(), so all three "full window" forms return the
+    # same set; narrowing to_time to the midpoint returns a strict, non-empty
+    # subset.
+    full = len(db.read_from_ts("float", from_time=before, to_time=after))
     assert (
-        len(db.read_from_ts("float", from_time=before, to_time=after))
+        full
         == len(db.read_from_ts("float", to_time=after))
         == len(db.read_from_ts("float", from_time=before))
         == 200
     )
 
-    assert len(db.read_from_ts("float", from_time=before, to_time=mid)) < 200
+    assert 0 < len(db.read_from_ts("float", from_time=before, to_time=mid)) < 200
 
 
 def test_database_limit_rows(database, db_limit_rows):


### PR DESCRIPTION
Clean promotion of develop's tree to master for **1.5.0** (a single commit; avoids the squash-divergence conflicts on a direct develop→master PR). Tree is verified identical to develop.

Contents since 1.4.0: logs viewer (search/export/full-screen, #92), export/search `tail=all` fix (#93), dashboard polish (#94), top-bias gap (#96), denser rows (#98), flaky `test_read_timerange` stabilization (#95/#97), CHANGES.md 1.5.0.

After merge: GitHub Release `1.5.0` off master → Docker Hub `daeploy/manager:1.5.0` + `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)